### PR TITLE
Fixed [statuses/lookup] validation to work correctly

### DIFF
--- a/lib/actions/statuses/lookup.js
+++ b/lib/actions/statuses/lookup.js
@@ -4,7 +4,7 @@ var util = require('../../util');
 var Joi  = require('@hapi/joi');
 
 var optionsSchema = Joi.object().keys({
-  id               : Joi.array().includes(Joi.string()).required(),
+  id               : Joi.array().items(Joi.string()).required(),
   include_entities : Joi.boolean(),
   trim_user        : Joi.boolean(),
   map              : Joi.boolean(),

--- a/test/lib/statuses/lookup.spec.js
+++ b/test/lib/statuses/lookup.spec.js
@@ -1,0 +1,20 @@
+/* global describe, it, beforeEach, afterEach */
+'use strict';
+
+var expect = require('chai').expect;
+const { ValidationError } = require('@hapi/joi');
+var lookup = require('../../../lib/actions/statuses/lookup');
+
+describe('statuses/lookup', function() {
+
+  describe('optionsSchema', function() {
+
+    const validationResponse = lookup.optionsSchema.validate({});
+    expect(validationResponse, JSON.stringify(validationResponse)).to.not.be.null;
+    expect(validationResponse.error, JSON.stringify(validationResponse.error)).to.not.be.null;
+    expect(validationResponse.error).to.be.instanceOf(ValidationError);
+    expect(validationResponse.error.message).to.contain('"id" is required')
+
+  })
+
+});


### PR DESCRIPTION
Was using an older version of Joi for validation and the API had changed at one point.
Introduced schema test to ensure that package version doesn't break this again.